### PR TITLE
Do not set the preimage

### DIFF
--- a/app/html/webcomponent.svelte
+++ b/app/html/webcomponent.svelte
@@ -369,9 +369,6 @@
 			amount,
 			customRecords: {
 				"7629169": JSON.stringify(boost),
-				// A random uuid MUST be assigned to 5482373484.
-				"5482373484": uuidv4(),
-				/* 
                     Some Lightning wallets MUST have a customKey and customValue,
                     or the funds will be lost (they'll end up with the Lightning node operator)
                     instead of the intended wallet recipient.


### PR DESCRIPTION
`5482373484` is the preimage of the payment. It must be a 32 byte hex value but typicaly wallets should take care of setting this.  Some wallets (e.g. LDK based) fail if this record is set as custom record manually.

I don't see why it was set here. Also I think the native podverse app also does not set it. 

Note: I've made this change here on GitHub without running the code. 
I gess the uuid library can also be removed maybe here.